### PR TITLE
Feature/allow to run from shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@
         DATABASE_DIR \
         --javascript.script CONFIGURATION.js
 
+# Start from arangosh
+
+    arangosh \
+         -c none \
+         --javascript.startup-directory /usr/share/arangodb3/js \
+         --javascript.module-directory `pwd` \
+         --javascript.execute CONFIGURATION.js \
+         --server.endpoint tcp://127.0.0.1:8529 \
+         --server.username <user>
+         --server.password <secret>
+
+Note: You need to have an ArangoDB running on this endpoint (or change it)
+Also Note: the test will create now collections with the _system database on this endpoint.
+Also Note: if you do not use authentication you either want to set the --server.password to some
+random value or use --server.authentication false otherwise a prompt asking for the
+password will halt the execution until responded.
+
 ## Configurations
 
 - run-small-crud.js

--- a/run-big-all.js
+++ b/run-big-all.js
@@ -1,4 +1,4 @@
-function main () {
+function main() {
   require('./test').test({
     outputCsv: true,
     small: false,
@@ -11,4 +11,7 @@ function main () {
     crud: true,
     crudSearch: true
   });
+}
+if (!require('internal').isArangod()) {
+  main();
 }

--- a/run-small-all-junit.js
+++ b/run-small-all-junit.js
@@ -1,4 +1,4 @@
-function main () {
+function main() {
   require('./test').test({
     outputXml: true,
     xmlDirectory: 'xml',
@@ -12,4 +12,7 @@ function main () {
     crud: true,
     crudSearch: true
   });
+}
+if (!require('internal').isArangod()) {
+  main();
 }

--- a/run-small-all.js
+++ b/run-small-all.js
@@ -1,4 +1,4 @@
-function main () {
+function main() {
   require('./test').test({
     outputCsv: true,
     small: true,
@@ -10,4 +10,7 @@ function main () {
     crud: true,
     crudSearch: true
   });
+}
+if (!require('internal').isArangod()) {
+  main();
 }

--- a/run-small-crud.js
+++ b/run-small-crud.js
@@ -1,3 +1,6 @@
-function main () {
-  require('./test').test({ small: true, crud: true });
+function main() {
+  require('./test').test({small: true, crud: true});
+}
+if (!require('internal').isArangod()) {
+  main();
 }

--- a/run-small-documents.js
+++ b/run-small-documents.js
@@ -1,3 +1,6 @@
-function main () {
-  require('./test').test({ small: true, documents: true });
+function main() {
+  require('./test').test({small: true, documents: true});
+}
+if (!require('internal').isArangod()) {
+  main();
 }

--- a/run-small-edges.js
+++ b/run-small-edges.js
@@ -1,4 +1,4 @@
-function main () {
+function main() {
   require('./test').test({
     outputCsv: true,
     small: true,
@@ -10,4 +10,7 @@ function main () {
     crud: false,
     crudSearch: false
   });
+}
+if (!require('internal').isArangod()) {
+  main();
 }


### PR DESCRIPTION
Allow to run the performance tests from shell and arangod alike.
This is use-full to run the tests against a cluster and a single server.
Based on:
https://github.com/arangodb/simple-performance-test/pull/10