### PR TITLE
Bug fix/make edges insert again

### DIFF
--- a/test.js
+++ b/test.js
@@ -307,8 +307,8 @@ exports.test = function (global) {
     fillCollection(c, n, function (i) {
       let obj = {
         _key: "test" + i,
-        _from: vc.name + "/test" + j,
-        _to: vc.name + "/test" + i,
+        _from: `${vc.name()}/test${j}`,
+        _to: `${vc.name()}/test${i}`,
         value: i + "-" + j
       };
       if (++l === k) {

--- a/test.js
+++ b/test.js
@@ -294,7 +294,7 @@ exports.test = function (global) {
       }
     }
 
-    if (batch.length === batchSize) {
+    if (batch.length > 0) {
       print("inserted", batch.length, "documents");
       c.insert(batch);
     }


### PR DESCRIPTION
There is a bug in the edge insertion command.
The vertex collection name is not properly injected => No edges will be stored.