### PR TITLE
Always set collectionLabel and -Size

### DIFF
--- a/simple/test.js
+++ b/simple/test.js
@@ -182,6 +182,9 @@ exports.test = function (global) {
               if (collection !== null) {
                 result.collectionLabel = collection.label;
                 result.collectionSize = collection.size;
+              } else {
+                result.collectionLabel = "";
+                result.collectionSize = 0;
               }
 
               out.push(result);


### PR DESCRIPTION
The IOless tests (#32) did not set `collectionSize` and `collectionLabel`, leaving them `undefined` and resulting in CSV rows unparseable by the corresponding arangoimport scripts, e.g.:
```
collect-unique-sorted,0.0112,0.0119,0.0098,0.0140,36.81,undefined,undefined,5,tiny
```
In that case, those are now set to `0` respectively `""`, resulting in
```
collect-unique-sorted,0.0077,0.0084,0.0062,0.0094,41.78,,0,5,tiny 
```
instead.