### PR TITLE
Fix serverVersion check

### DIFF
--- a/simple/test.js
+++ b/simple/test.js
@@ -33,7 +33,8 @@ exports.test = function (global) {
   const semver = require("semver");
   const _ = require("lodash");
 
-  const serverVersion = ((typeof arango) !== "undefined") ? arango.getVersion() : internal.version;
+  // Substring first 5 characters to limit to A.B.C format and not use any `nightly`, `rc`, `preview` etc.
+  const serverVersion = (((typeof arango) !== "undefined") ? arango.getVersion() : internal.version).slice(0,5);
 
   const db = require("org/arangodb").db;
   const time = internal.time;

--- a/simple/test.js
+++ b/simple/test.js
@@ -34,7 +34,7 @@ exports.test = function (global) {
   const _ = require("lodash");
 
   // Substring first 5 characters to limit to A.B.C format and not use any `nightly`, `rc`, `preview` etc.
-  const serverVersion = (((typeof arango) !== "undefined") ? arango.getVersion() : internal.version).slice(0,5);
+  const serverVersion = (((typeof arango) !== "undefined") ? arango.getVersion() : internal.version).split("-")[0];
 
   const db = require("org/arangodb").db;
   const time = internal.time;


### PR DESCRIPTION
In order to avoid the following
```
127.0.0.1:8529@_system> semver.satisfies("3.8.0-rc.2", ">= 3.4.5")
false

127.0.0.1:8529@_system> semver.satisfies("3.8.0", ">= 3.4.5")
true
```
we will reduce `serverVersion` to characters prior to the first "-".

It seems to be OK since any `X.Y` branch has internally defined actual version with `X.Y.X` base.