### PR TITLE
Add more crud tests, disable non-spliced subqueries tests for >=3.9 and more.

### DIFF
--- a/simple/test.js
+++ b/simple/test.js
@@ -138,6 +138,7 @@ exports.test = function (global) {
   const supportsAnalyzers = !semver.satisfies(serverVersion,
     "3.5.0-rc.1 || 3.5.0-rc.2 || 3.5.0-rc.3");
   const supportsSatelliteGraphs = semver.satisfies(serverVersion, ">=3.7.0-devel");
+  const supportsOnlySplicedSubqueries = semver.satisfies(serverVersion, ">=3.9");
 
   let silent = true;
   let testRunner = function (tests, options) {
@@ -3305,14 +3306,10 @@ exports.test = function (global) {
         /* We run each test case with splicing enabled and with splicing disabled */
         var subqueryTestsCases = [];
         subqueryTests.forEach(function (item) {
-          var noSplicingCase = _.cloneDeep(item);
-          noSplicingCase.name = noSplicingCase.name + "-no-splicing";
-          noSplicingCase.params.splice = false;
-          subqueryTestsCases.push(noSplicingCase);
-          var yesSplicingCase = _.cloneDeep(item);
-          yesSplicingCase.name = yesSplicingCase.name + "-yes-splicing";
-          yesSplicingCase.params.splice = true;
-          subqueryTestsCases.push(yesSplicingCase);
+          if (!supportsOnlySplicedSubqueries) {
+            subqueryTestsCases.push({...item, name: item.name + "-no-splicing", params: {...item.params, splice: false}});
+          }
+          subqueryTestsCases.push({...item, name: item.name + "-yes-splicing", params: {...item.params, splice: true}});
         });
 
         let subqueryTestsResult = testRunner(subqueryTestsCases, options);

--- a/simple/test.js
+++ b/simple/test.js
@@ -115,14 +115,16 @@ exports.test = function (global) {
   const replicationFactor = global.replicationFactor || 1;
   const writeConcern = global.writeConcern || replicationFactor;
 
-  // Substring first 5 characters to limit to A.B.C format and not use any `nightly`, `rc`, `preview` etc.
-  const serverVersion = (((typeof arango) !== "undefined") ? arango.getVersion() : internal.version).split("-")[0];
-
   const time = internal.time;
   const print = internal.print;
+  
+  // Substring first 5 characters to limit to A.B.C format and not use any `nightly`, `rc`, `preview` etc.
+  const serverVersion = (((typeof arango) !== "undefined") ? arango.getVersion() : internal.version).split("-")[0]
   const isEnterprise = internal.isEnterprise();
   const isCluster = semver.satisfies(serverVersion, "<3.5.0") ? require("@arangodb/cluster").isCluster() : internal.isCluster();
 
+  print(`Running against version ${serverVersion} ${isEnterprise ? "Enterprise" : ""} ${isCluster ? "Cluster" : ""}`);
+  
   const supportsAnalyzers = !semver.satisfies(serverVersion,
     "3.5.0-rc.1 || 3.5.0-rc.2 || 3.5.0-rc.3");
   const supportsSatelliteGraphs = semver.satisfies(serverVersion, ">=3.7.0-devel");

--- a/simple/test.js
+++ b/simple/test.js
@@ -111,6 +111,8 @@ exports.test = function (global) {
   global.outputCsv = global.outputCsv || false;
 
   const numberOfShards = global.numberOfShards || 9;
+  const replicationFactor = global.replicationFactor || 1;
+  const writeConcern = global.writeConcern || replicationFactor;
 
   // Substring first 5 characters to limit to A.B.C format and not use any `nightly`, `rc`, `preview` etc.
   const serverVersion = (((typeof arango) !== "undefined") ? arango.getVersion() : internal.version).split("-")[0];
@@ -749,7 +751,7 @@ exports.test = function (global) {
 
     create = function (params) {
       let name = params.collection;
-      db._create(name, {numberOfShards});
+      db._create(name, {numberOfShards, replicationFactor, writeConcern});
       let view = params.view;
       if (view !== undefined) {
         let viewParams = {

--- a/simple/test.js
+++ b/simple/test.js
@@ -26,6 +26,12 @@ function calc(values, options) {
     }
   }
 
+  const stddev = array => {
+    const n = array.length;
+    const mean = _.mean(array);
+    return Math.sqrt(array.map(x => Math.pow(x - mean, 2)).reduce((a, b) => a + b) / n);
+  };
+
   const n = values.length;
   return {
     min: values[0],
@@ -39,7 +45,8 @@ function calc(values, options) {
         : values[n / 2]),
     dev: n === 1
       ? values[0]
-      : (values[n - 1] - values[0]) / (sum(values) / n)
+      : (values[n - 1] - values[0]) / (sum(values) / n),
+    stddev: stddev(values)
   };
 };
 
@@ -54,6 +61,7 @@ function toAsciiTable(title, out) {
       "max (s)",
       "% dev",
       "avg (s)",
+      "stddev (s)",
       "med (s)",
       "total (s)"
     ).
@@ -63,7 +71,8 @@ function toAsciiTable(title, out) {
     setAlign(5, AsciiTable.RIGHT).
     setAlign(6, AsciiTable.RIGHT).
     setAlign(7, AsciiTable.RIGHT).
-    setAlign(8, AsciiTable.RIGHT);
+    setAlign(8, AsciiTable.RIGHT).
+    setAlign(9, AsciiTable.RIGHT);
 
   for (let i = 0; i < out.length; ++i) {
     let test = out[i];
@@ -75,6 +84,7 @@ function toAsciiTable(title, out) {
       test.max,
       test.dev,
       test.avg,
+      test.stddev,
       test.med,
       test.total
     );
@@ -228,6 +238,7 @@ exports.test = function (global) {
                 max: stats.max.toFixed(options.digits),
                 dev: (stats.dev * 100).toFixed(2),
                 avg: stats.avg.toFixed(options.digits),
+                stddev: stats.stddev.toFixed(options.digits),
                 med: stats.med.toFixed(options.digits),
                 total: (endTotal - startTotal).toFixed(options.digits),
               };

--- a/simple/test.js
+++ b/simple/test.js
@@ -210,6 +210,7 @@ exports.test = function (global) {
 
     let run = function (tests, options) {
       let out = [];
+      let errors = [];
 
       for (let i = 0; i < tests.length; ++i) {
         let test = tests[i];
@@ -255,10 +256,11 @@ exports.test = function (global) {
           }
         } catch (ex) {
           print("exception in test " + test.name + ": " + ex);
+          errors.push({ test: test.name, error: ex });
         }
       } // for i
 
-      return out;
+      return { results: out, errors };
     };
 
     return run(tests, options);
@@ -3003,9 +3005,12 @@ exports.test = function (global) {
         options;
 
       const runTestSuite = function (name, tests, options) {
-        const testsResults = testRunner(tests, options);
+        const { results: testsResults, errors } = testRunner(tests, options);
         result.results[name] = testsResults;
         output += toAsciiTable(name, testsResults) + "\n\n";
+        for (const err of errors) {
+          output += `Test ${err.name} failed with exception: ${err.error}\n`;
+        }
 
         if (global.outputXml) {
           toJUnit(testsResults);


### PR DESCRIPTION
* add babies crud tests
* add single document crud tests for update/replace/remove with more efficient setup
* mark old single document crud tests as legacy (these use expensive single doc setup that on top of is is _inside_ the measured code path)
* disable non-spliced subqueries tests for versions >=3.9 since spliced subqueries are no longer optional
* add configuration options for replicationFactor and writeConcern
* add optional json output
* add stddev and total runtime (incl setup/teardown) columns